### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Hard coded event data like name is stored in XML file.
 A copy of the event name is stored as Enum to link
 Calculator Methods with data from XML.
 These static methods are the logic to check
-if an event occured. No astro calculation done at this stage.
+if an event occurred. No astro calculation done at this stage.
 This is the linking process of the logic and data.
 
                       -------+


### PR DESCRIPTION
Corrected "occured" to "occurred" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.